### PR TITLE
Update window title, template and build using emcmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,10 @@ project(
   DESCRIPTION "John Conway's Game of Life for SDL2/Wasm"
 )
 
-include(FetchContent)
-include(cmake/CMakeRC.cmake)
-include(CheckLibraryExists)
+if (NOT EMSCRIPTEN)
+  include(FetchContent)
+  include(cmake/CMakeRC.cmake)
+  include(CheckLibraryExists)
+endif()
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You need [CMake](https://cmake.org/) version 3.19 or higher:
 cmake -S . -B build && cmake --build build && cmake --install build
 ```
 ### Browser (WebAssembly)
-You need [Emscripten](https://emscripten.org/):
+You need [emsdk](https://emscripten.org/) 3.1.63 or higher.
+#### Manually
 ```bash
 em++ src/gol.cpp -o index.html --shell-file src/template.html --preload-file src/font.ttf --use-port=sdl2 --use-port=sdl2_ttf -s ALLOW_MEMORY_GROWTH
 ```
@@ -21,3 +22,10 @@ And for running:
 ```bash
 emrun index.html
 ```
+#### Using CMake
+```
+emcmake cmake -S . -B build-web && cmake --build build-web
+```
+And for running
+```
+emrun build-web/src/gol2p.html

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,67 +19,86 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-cmrc_add_resource_library(
-  gol2p-resources
-  ALIAS gol2p::rc
-  NAMESPACE gol2p
-  font.ttf
-  )
-set(SDL2_LIBS gol2p::rc)
-
 add_executable(${PROJECT_NAME} gol.cpp)
 
-find_package(
-  SDL2 CONFIG
-  HINTS $ENV{HOME} /usr/local /opt/local /opt
-)
-if(NOT SDL2_FOUND)
-  CHECK_LIBRARY_EXISTS(SDL2 SDL_Init "" SDL2_EXISTS)
-  if(SDL2_EXISTS)
-    list(APPEND SDL2_LIBS SDL2)
-  else()
-    message(STATUS "Fetching SDL2 library...")
-    FetchContent_Declare(
-      SDL
-      GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-      GIT_TAG        release-2.30.5
-    )
-    FetchContent_MakeAvailable(SDL)
-    list(APPEND SDL2_LIBS SDL2::SDL2-static)
-  endif()
+if (EMSCRIPTEN)
+  message(STATUS "Configuring for Emscripten")
+  set(SHELL_FILE template.html)
+  target_link_options(${PROJECT_NAME} PRIVATE
+    --use-port=sdl2
+    --use-port=sdl2_ttf
+    --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/font.ttf@src/font.ttf"
+    --shell-file   "${CMAKE_CURRENT_SOURCE_DIR}/${SHELL_FILE}"
+    -s ALLOW_MEMORY_GROWTH
+  )
+  set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".html")
+  # make sure the shell file is watched for changes
+  set_property(
+    TARGET ${PROJECT_NAME}
+    PROPERTY LINK_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/${SHELL_FILE}"
+  )
 else()
-  if(SDL2_VERSION VERSION_LESS "2.0.12")
-    target_include_directories(gol2p PRIVATE ${SDL2_INCLUDE_DIRS})
-    target_link_libraries(gol2p PRIVATE ${SDL2_LIBRARIES})
-  else()
-    list(APPEND SDL2_LIBS $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
-  endif()
-endif()
-
-find_package(
-  SDL2_ttf CONFIG
-  HINTS $ENV{HOME} /usr/local /opt/local /opt
-)
-if(NOT SDL2_ttf_FOUND)
-  CHECK_LIBRARY_EXISTS(SDL2_ttf TTF_Init "" SDL2_ttf_EXISTS)
-  if(SDL2_ttf_EXISTS)
-    list(APPEND SDL2_LIBS SDL2_ttf)
-  else()
-    message(STATUS "Fetching SDL2_ttf library...")
-    FetchContent_Declare(
-      SDL_ttf
-      GIT_REPOSITORY https://github.com/libsdl-org/SDL_ttf.git
-      GIT_TAG        release-2.22.0
+  cmrc_add_resource_library(
+    gol2p-resources
+    ALIAS gol2p::rc
+    NAMESPACE gol2p
+    font.ttf
     )
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build the library as a shared library")
-    FetchContent_MakeAvailable(SDL_ttf)
-    list(APPEND SDL2_LIBS SDL2_ttf::SDL2_ttf-static)
+  set(SDL2_LIBS gol2p::rc)
+
+  find_package(
+    SDL2 CONFIG
+    HINTS $ENV{HOME} /usr/local /opt/local /opt
+  )
+  if(NOT SDL2_FOUND)
+    CHECK_LIBRARY_EXISTS(SDL2 SDL_Init "" SDL2_EXISTS)
+    if(SDL2_EXISTS)
+      list(APPEND SDL2_LIBS SDL2)
+    else()
+      message(STATUS "Fetching SDL2 library...")
+      FetchContent_Declare(
+        SDL
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
+        GIT_TAG        release-2.30.5
+      )
+      FetchContent_MakeAvailable(SDL)
+      list(APPEND SDL2_LIBS SDL2::SDL2-static)
+    endif()
+  else()
+    if(SDL2_VERSION VERSION_LESS "2.0.12")
+      target_include_directories(gol2p PRIVATE ${SDL2_INCLUDE_DIRS})
+      target_link_libraries(gol2p PRIVATE ${SDL2_LIBRARIES})
+    else()
+      list(APPEND SDL2_LIBS $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
+    endif()
   endif()
-else()
-  list(APPEND SDL2_LIBS $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)
+
+  find_package(
+    SDL2_ttf CONFIG
+    HINTS $ENV{HOME} /usr/local /opt/local /opt
+  )
+  if(NOT SDL2_ttf_FOUND)
+    CHECK_LIBRARY_EXISTS(SDL2_ttf TTF_Init "" SDL2_ttf_EXISTS)
+    if(SDL2_ttf_EXISTS)
+      list(APPEND SDL2_LIBS SDL2_ttf)
+    else()
+      message(STATUS "Fetching SDL2_ttf library...")
+      FetchContent_Declare(
+        SDL_ttf
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL_ttf.git
+        GIT_TAG        release-2.22.0
+      )
+      set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build the library as a shared library")
+      FetchContent_MakeAvailable(SDL_ttf)
+      list(APPEND SDL2_LIBS SDL2_ttf::SDL2_ttf-static)
+    endif()
+  else()
+    list(APPEND SDL2_LIBS $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)
+  endif()
+
+  target_link_libraries(${PROJECT_NAME} PRIVATE ${SDL2_LIBS})
+
+  include(GNUInstallDirs)
+  install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
-
-target_link_libraries(${PROJECT_NAME} PRIVATE ${SDL2_LIBS})
-
-include(GNUInstallDirs)
-install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/gol.cpp
+++ b/src/gol.cpp
@@ -35,11 +35,9 @@
     CMRC_DECLARE(gol2p);
 #endif // __EMSCRIPTEN__
 
-const int WINDOW_WIDTH = 800;
-const int WINDOW_HEIGHT = 600;
-const int CELL_SIZE = 3;
-const int ROWS = WINDOW_HEIGHT / CELL_SIZE;
-const int COLS = WINDOW_WIDTH / CELL_SIZE;
+const size_t WINDOW_WIDTH = 800;
+const size_t WINDOW_HEIGHT = 600;
+const size_t CELL_SIZE = 3;
 
 struct cellular_automaton_grid
 {   cellular_automaton_grid(size_t rows, size_t cols)

--- a/src/gol.cpp
+++ b/src/gol.cpp
@@ -119,8 +119,10 @@ struct rendering_context
     ,   grid_(nullptr)
     {   SDL_Init(SDL_INIT_VIDEO);
         TTF_Init();
+        std::string title = "John Conway's Game of Life - v1.1 - ";
+        title += SDL_GetPlatform();
         window_ = SDL_CreateWindow
-        (   "John Conway's Game of Life"
+        (   title.c_str()
         ,   SDL_WINDOWPOS_UNDEFINED
         ,   SDL_WINDOWPOS_UNDEFINED
         ,   width_
@@ -238,8 +240,7 @@ int main(int argc, char* args[])
 
     SDL_DisplayMode dm;
     SDL_GetCurrentDisplayMode(0, &dm);
-    std::cout << "John Conway's Game of Life v1.1\n"
-              << "Copyright © 2024 Armin Sobhani\n"
+    std::cout << "Copyright (C) 2024 Armin Sobhani\n"
               << "Display size: " << dm.w << "x" << dm.h << "\n"
               << "Window size:  " << WINDOW_WIDTH << "x" << WINDOW_HEIGHT
               << std::endl;

--- a/src/gol.cpp
+++ b/src/gol.cpp
@@ -26,11 +26,12 @@
 
 #define SDL_MAIN_HANDLED
 #include <SDL2/SDL.h>
-#include <SDL_ttf.h>
 
 #ifdef __EMSCRIPTEN__
 #   include <emscripten.h>
+#   include <SDL2/SDL_ttf.h>
 #else
+#   include <SDL_ttf.h>
 #   include <cmrc/cmrc.hpp>
     CMRC_DECLARE(gol2p);
 #endif // __EMSCRIPTEN__

--- a/src/template.html
+++ b/src/template.html
@@ -10,6 +10,13 @@
   padding: none;
 }
 
+h1 {
+  font-size: 32px;
+  text-align: center;
+  margin: 6px;
+  color: rgb(100, 100, 100);
+}
+
 .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
 div.emscripten { text-align: center; }
 div.emscripten_border { border: 1px solid black; }
@@ -103,6 +110,7 @@ canvas.emscripten { border: 0px none; background-color: black; }
 </style>
   </head>
   <body>
+    <h1>John Conway's Game of Life - v1.1</h1>
     <div class="spinner" id='spinner'></div>
     <div class="emscripten" id="status">Downloading...</div>
 


### PR DESCRIPTION
This pull request includes the following changes:

- Update the window title with SDL platform information

- Update `gol.cpp` to use `size_t` for window dimensions and remove unused constants

- Update `template.html` to include a centered h1 heading title

- Add support for building web version using emcmake

These changes improve the user experience by providing more accurate and informative window titles, using the appropriate data type for window dimensions, and enhancing the visual appearance of the web page.